### PR TITLE
Fix error message text: Change "submision" to "submission" in proof price errors

### DIFF
--- a/crates/prooflab/src/lib.rs
+++ b/crates/prooflab/src/lib.rs
@@ -215,12 +215,12 @@ pub async fn submit_proof_to_aligned(
         })?;
 
     let format_max_fee = format_units(max_fee, "ether").map_err(|e| {
-        error!("Unable to convert estimated proof submision price");
+        error!("Unable to convert estimated proof submission price");
         SubmitError::GenericError(e.to_string())
     })?;
 
     let format_user_balance = format_units(user_balance, "ether").map_err(|e| {
-        error!("Unable to convert estimated proof submision price");
+        error!("Unable to convert estimated proof submission price");
         SubmitError::GenericError(e.to_string())
     })?;
 


### PR DESCRIPTION
This PR fixes a typo in error messages where "submision" was incorrectly spelled. The change updates two instances of the error message text from "Unable to convert estimated proof submision price" to "Unable to convert estimated proof submission price" in lib.rs.

Changes:
- Corrected spelling in format_max_fee error message
- Corrected spelling in format_user_balance error message